### PR TITLE
Add Python port of dead reference link replacement tool

### DIFF
--- a/tools/dev/find_and_replace_dead_reference_links.py
+++ b/tools/dev/find_and_replace_dead_reference_links.py
@@ -112,12 +112,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    try:
-        json_data = load_json(args.file)
-        replace_links_in_files(json_data)
-    except Exception as exc:  # pylint: disable=broad-except
-        print(f"An error occurred: {exc}")
-
-
+    json_data = load_json(args.file)
+    replace_links_in_files(json_data)
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add a Python implementation of `tools/dev/find_and_replace_dead_reference_links.rb`
- provide CLI argument parsing and helpful console messages

## Testing
- python3 -m py_compile tools/dev/find_and_replace_dead_reference_links.py

------
https://chatgpt.com/codex/tasks/task_e_68ec005abcb48329829243e65ec3c966